### PR TITLE
Login und generelle Authentifizierung verbessert

### DIFF
--- a/app/src/main/java/com/example/workoutwizard/data/AuthUiState.kt
+++ b/app/src/main/java/com/example/workoutwizard/data/AuthUiState.kt
@@ -6,7 +6,6 @@ enum class AuthType(val title: String) {
 }
 
 data class AuthUiState(
-    val username: String = "",
+    val email: String = "",
     val password: String = "",
-    val authType: AuthType = AuthType.LOGIN
 )

--- a/app/src/main/java/com/example/workoutwizard/ui/AuthScreen.kt
+++ b/app/src/main/java/com/example/workoutwizard/ui/AuthScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.workoutwizard.R
@@ -31,17 +30,21 @@ import com.example.workoutwizard.ui.components.ImageFillSizeAlpha
 import com.example.workoutwizard.ui.components.InputField
 import com.example.workoutwizard.ui.components.InputFieldPassword
 import com.example.workoutwizard.ui.model.AuthViewModel
-import com.example.workoutwizard.ui.theme.WorkoutWizardTheme
-import com.google.firebase.auth.FirebaseAuth
 
 @Composable
 fun AuthLayout(
     modifier: Modifier = Modifier,
     onChangeAuthTypeClick: () -> Unit = {},
     onAuthButtonClick: () -> Unit = {},
-    authViewModel: AuthViewModel = viewModel()
+    authViewModel: AuthViewModel = viewModel(),
+    route: String?
 ) {
     val authUiState by authViewModel.uiState.collectAsState()
+
+    val authType =
+        if (route != null && route == AuthType.LOGIN.name)
+            AuthType.LOGIN
+        else AuthType.REGISTER
 
     Box(
         modifier = modifier
@@ -70,15 +73,15 @@ fun AuthLayout(
         AuthUserInput(
             modifier = Modifier
                 .align(Alignment.Center),
-            usernameValue = authUiState.username,
+            usernameValue = authUiState.email,
             passwordValue = authUiState.password,
-            authButtonText = authUiState.authType.title,
-            usernameValueChange = { authViewModel.onChangeUsername(it) },
+            authType = authType,
+            usernameValueChange = { authViewModel.onChangeEmail(it) },
             passwordValueChange = { authViewModel.onChangePassword(it) },
             onAuthButtonClick = onAuthButtonClick
         )
         AuthChange(
-            authType = authUiState.authType,
+            authType = authType,
             onChangeAuthTypeClick = onChangeAuthTypeClick,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
@@ -92,7 +95,7 @@ fun AuthUserInput(
     passwordValue: String,
     usernameValueChange: (String) -> Unit,
     passwordValueChange: (String) -> Unit,
-    authButtonText: String,
+    authType: AuthType,
     onAuthButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -103,12 +106,18 @@ fun AuthUserInput(
             bottom = 4.dp
         )
 
+    val authTypeReadable = if (authType == AuthType.LOGIN) "Login" else "Registrieren"
+
     Column(
         modifier = modifier
             .padding(
                 dimensionResource(id = R.dimen.auth_column_padding)
             )
     ) {
+        Text(
+            text =  authTypeReadable,
+            style = MaterialTheme.typography.headlineMedium,
+        )
         InputField(
             value = usernameValue,
             onValueChange = usernameValueChange,
@@ -130,7 +139,7 @@ fun AuthUserInput(
             )
         ) {
             Text(
-                text = authButtonText,
+                text = authTypeReadable,
                 style = MaterialTheme.typography.titleMedium
             )
         }

--- a/app/src/main/java/com/example/workoutwizard/ui/model/AuthViewModel.kt
+++ b/app/src/main/java/com/example/workoutwizard/ui/model/AuthViewModel.kt
@@ -1,34 +1,86 @@
 package com.example.workoutwizard.ui.model
 
+import android.util.Log
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.lifecycle.ViewModel
+import androidx.navigation.NavHostController
 import com.example.workoutwizard.data.AuthType
 import com.example.workoutwizard.data.AuthUiState
+import com.example.workoutwizard.data.InitialUserDataStage
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class AuthViewModel: ViewModel() {
     private val _uiState = MutableStateFlow(AuthUiState())
     val uiState: StateFlow<AuthUiState> = _uiState.asStateFlow()
 
-    fun changeAuthType() {
-        val authType = if (uiState.value.authType == AuthType.LOGIN) AuthType.REGISTER else AuthType.LOGIN
-        _uiState.update {
-            currentState ->
-                currentState.copy(
-                    authType = authType,
-                    username = "",
-                    password = ""
-                )
+    val loginButtonClick: (FirebaseAuth, CoroutineScope, SnackbarHostState, NavHostController) -> Unit = {
+            auth, scope, snackbarHostState, navController ->
+                var toastMessage = ""
+                try {
+                    auth.signInWithEmailAndPassword(
+                    uiState.value.email,
+                    uiState.value.password
+                ).addOnCompleteListener {
+                        task ->
+                    if (task.isSuccessful) {
+                        val user = auth.currentUser
+                        Log.i("AuthViewModel", user.toString())
+                        navController.navigate(InitialUserDataStage.USER_DATA_INPUT.name)
+                    } else {
+                        toastMessage = "Login fehlgeschlagen. Versuchen Sie es erneut."
+                        toastFeedback(scope, snackbarHostState, toastMessage)
+                    }
+                }
+        } catch(exception: IllegalArgumentException) {
+            toastMessage = "Sie müssen ihre Daten eingeben."
+            toastFeedback(scope, snackbarHostState, toastMessage)
         }
     }
 
-    fun onChangeUsername(usernameInput: String) {
+    val registerButtonClick: (FirebaseAuth, CoroutineScope, SnackbarHostState, NavHostController) -> Unit = {
+        auth, scope, snackbarHostState, navController ->
+            var toastMessage = ""
+            try {
+                auth.createUserWithEmailAndPassword(
+                    uiState.value.email,
+                    uiState.value.password
+                ).addOnCompleteListener {
+                    task ->
+                        if (task.isSuccessful) {
+                            toastMessage = "Registrierung von ${uiState.value.email} erfolgreich. Sie können sich jetzt einloggen."
+                            navController.navigate(AuthType.LOGIN.name)
+                        } else {
+                            toastMessage = "Registrierung fehlgeschlagen. Versuchen Sie es erneut."
+                        }
+                        toastFeedback(scope, snackbarHostState, toastMessage)
+                }
+            } catch(exception: IllegalArgumentException) {
+                toastMessage = "Sie müssen ihre Daten eingeben."
+                toastFeedback(scope, snackbarHostState, toastMessage)
+            }
+    }
+
+    val toastFeedback: (CoroutineScope, SnackbarHostState, String) -> Unit = {
+        scope, snackbarHostState, message ->
+            scope.launch {
+                snackbarHostState.showSnackbar(
+                    message = message
+                )
+            }
+    }
+
+    fun onChangeEmail(emailInput: String) {
         _uiState.update {
             currentState ->
                 currentState.copy(
-                    username = usernameInput
+                    email = emailInput
                 )
         }
     }
@@ -41,4 +93,6 @@ class AuthViewModel: ViewModel() {
                 )
         }
     }
+
+
 }


### PR DESCRIPTION
- Die Route wird jetzt dem AuthScreen mitgegeben und dort wird ausgelesen, ob der Benutzer sich auf der Login oder Registrieren Seite befindet.
- authType von AuthUiState wurde entfernt, da nicht mehr benötigt
- Separate Click-Handler für Login und Registrieren + Lambda-Funktion für toastFeedback
- Auf den Seiten der Dateneingabe wird kein extra Padding mehr angewendet.